### PR TITLE
Issue-24 Refactor MySqlCompiler.cs

### DIFF
--- a/QueryBuilder/Compilers/MySqlCompiler.cs
+++ b/QueryBuilder/Compilers/MySqlCompiler.cs
@@ -2,6 +2,7 @@ namespace SqlKata.Compilers
 {
     public class MySqlCompiler : Compiler
     {
+        const string MAX_MySQL_LIMIT = "18446744073709551615";
         public MySqlCompiler()
         {
             OpeningIdentifier = ClosingIdentifier = "`";
@@ -34,7 +35,7 @@ namespace SqlKata.Compilers
                 // to avoid this error.
 
                 context.Bindings.Add(offset);
-                return "LIMIT 18446744073709551615 OFFSET ?";
+                return "LIMIT " + MAX_MySQL_LIMIT + " OFFSET ?";
             }
 
             // We have both values


### PR DESCRIPTION
extract mySQL limit out into a string, unit tests pass still

Refactor the ifs statement and extract 18446744073709551615 to 2^64 in MySqlCompiler.cs 